### PR TITLE
fix: pop thresholds

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -7,9 +7,10 @@ This page contains the help content for the `clam` command-line program.
 
 **Command Overview:**
 
-* [`clam`↴](#clam)
-* [`clam loci`↴](#clam-loci)
-* [`clam stat`↴](#clam-stat)
+- [Command-Line Help for `clam`](#command-line-help-for-clam)
+  - [`clam`](#clam)
+  - [`clam loci`](#clam-loci)
+  - [`clam stat`](#clam-stat)
 
 ## `clam`
 
@@ -53,7 +54,7 @@ Sample-level Thresholds:
       --thresholds-file <THRESHOLD_FILE>
           Custom thresholds per chromosome. Tab-separated file: chrom, min, max
 
-Population-level Thresholds:
+Site-level Thresholds:
   -d, --depth-proportion <DEPTH_PROPORTION>
           Proportion of samples that must pass thresholds at a site to consider it callable. Value between 0.0 and 1.0 [default: 0]
   -u, --min-mean-depth <MEAN_DEPTH_MIN>

--- a/docs/tutorial/02_callable_loci.md
+++ b/docs/tutorial/02_callable_loci.md
@@ -47,8 +47,8 @@ The following options control if a site is considered callable at the sample lev
     chrX    15    150
     ```
 
-#### Population-Level Thresholds
-The following options control if a site is considered callable at the population level.
+#### Site-Level Thresholds
+The following options control if a site is considered callable.
 `-d, --depth-proportion`
 :  Proportion of samples that must pass thresholds (0.0-1.0, default: 0)
 

--- a/src/loci/mod.rs
+++ b/src/loci/mod.rs
@@ -96,15 +96,14 @@ pub struct LociArgs {
     )]
     pub threshold_file: Option<Utf8PathBuf>,
 
-    // === Population-level Threshold Options ===
+    // === Site-level Threshold Options ===
     /// Proportion of samples that must pass thresholds at a site to consider it callable.
     /// Value between 0.0 and 1.0.
     #[arg(
         short = 'd',
         long = "depth-proportion",
         default_value_t = 0.0,
-        conflicts_with("population_file"),
-        help_heading = "Population-level Thresholds"
+        help_heading = "Site-level Thresholds"
     )]
     pub depth_proportion: f64,
 
@@ -113,8 +112,7 @@ pub struct LociArgs {
         short = 'u',
         long = "min-mean-depth",
         default_value_t = 0.0,
-        conflicts_with("population_file"),
-        help_heading = "Population-level Thresholds"
+        help_heading = "Site-level Thresholds"
     )]
     pub mean_depth_min: f64,
 
@@ -123,8 +121,7 @@ pub struct LociArgs {
         short = 'U', 
         long = "max-mean-depth", 
         default_value_t = f64::INFINITY, 
-        conflicts_with("population_file"),
-        help_heading = "Population-level Thresholds"
+        help_heading = "Site-level Thresholds"
     )]
     pub mean_depth_max: f64,
 


### PR DESCRIPTION
rename population thresholds to site level. remove conflict between these filters and population file. 