### PR TITLE
feat: support custom sample names via SampleMap

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -74,6 +74,9 @@ Usage: clam loci [OPTIONS] --output <OUTPUT> <INPUT>...
 `--min-gq <MIN_GQ>`
 :   Minimum genotype quality (GQ) to count depth. Only applies to GVCF input.
 
+`--sample-file <SAMPLE_FILE>`
+:   Path to file mapping filenames to sample names. Tab-separated with columns: filename, sample_name (no header). Useful when filenames contain dots that interfere with automatic sample name extraction. See [Input Formats](input-formats.md#sample-name-file).
+
 ### Chromosome Filtering
 
 `-x, --exclude <EXCLUDE>...`
@@ -234,6 +237,9 @@ Usage: clam collect [OPTIONS] --output <OUTPUT> <INPUT>...
 `--min-gq <MIN_GQ>`
 :   Minimum genotype quality (GQ) to count depth. Only applies to GVCF input.
 
+`--sample-file <SAMPLE_FILE>`
+:   Path to file mapping filenames to sample names. Tab-separated with columns: filename, sample_name (no header). See [Input Formats](input-formats.md#sample-name-file).
+
 ### Chromosome Filtering
 
 `-x, --exclude <EXCLUDE>...`
@@ -286,3 +292,4 @@ These options are available across multiple commands:
 | `-i, --include` | Chromosomes to include (comma-separated) | all |
 | `--include-file` | File with chromosomes to include | all |
 | `--chunk-size` | Processing chunk size in bp | all |
+| `--sample-file` | Custom sample name mappings file | `loci`, `collect` |

--- a/docs/reference/input-formats.md
+++ b/docs/reference/input-formats.md
@@ -112,6 +112,35 @@ sample6	PopC
 
 ---
 
+## Sample Name File
+
+Override automatic sample name detection from filenames. Useful when filenames contain dots (e.g., "L.sample1.d4" would be auto-detected as "L" instead of "L.sample1").
+
+**Format:** Tab-separated, two columns, no header.
+
+| Column | Description |
+|--------|-------------|
+| 1 | Filename (not full path) |
+| 2 | Sample name |
+
+**Example:**
+
+```
+L.sample1.d4.gz	L.sample1
+L.sample2.d4.gz	L.sample2
+sample3.d4	sample3_renamed
+```
+
+**Notes:**
+
+- Use the filename only, not the full path
+- All input files must be listed when using this option
+- Sample names must be unique
+- Useful when files have dots in sample identifiers (e.g., species abbreviations like "L." or "D.")
+- Does not apply to multisample D4 files (sample names come from internal track names)
+
+---
+
 ## Chromosome Include/Exclude Files
 
 Specify chromosomes to include or exclude from analysis.
@@ -263,6 +292,7 @@ chr2	38814	46588
 | GVCF | `.g.vcf.gz` | `.g.vcf.gz.tbi` | `loci`, `collect` |
 | VCF | `.vcf.gz` | `.vcf.gz.tbi` | `stat` |
 | Population | `.tsv` | No | `loci`, `stat` |
+| Sample names | `.tsv` | No | `loci`, `collect` |
 | Chromosome list | `.txt` | No | `loci`, `stat`, `collect` |
 | Thresholds | `.tsv` | No | `loci` |
 | ROH | `.bed.gz` | `.bed.gz.tbi` | `stat` |

--- a/src/collect/mod.rs
+++ b/src/collect/mod.rs
@@ -1,13 +1,19 @@
 use crate::core::depth::array::stack_depths;
 use crate::core::depth::DepthProcessor;
-use crate::core::zarr::{DepthArrays, is_zarr_path};
-use color_eyre::Result;
-use color_eyre::Help;
+use crate::core::sample_map::SampleMap;
+use crate::core::zarr::{is_zarr_path, DepthArrays};
 use color_eyre::eyre::eyre;
+use color_eyre::Help;
+use color_eyre::Result;
 use std::path::PathBuf;
 
-
-pub fn run_collect(depth_files: Vec<PathBuf>, output_path: PathBuf, chunk_size: u64, min_gq: Option<isize>) -> Result<()> {
+pub fn run_collect(
+    depth_files: Vec<PathBuf>,
+    output_path: PathBuf,
+    chunk_size: u64,
+    min_gq: Option<isize>,
+    sample_map: Option<&SampleMap>,
+) -> Result<()> {
     if is_zarr_path(&output_path) {
         return Err(eyre!(
             "Output zarr path: {} already exists",
@@ -15,8 +21,8 @@ pub fn run_collect(depth_files: Vec<PathBuf>, output_path: PathBuf, chunk_size: 
         ))
         .suggestion("Remove the existing directory or choose a different output path");
     }
-    
-    let processor = DepthProcessor::from_paths(depth_files, min_gq)?;
+
+    let processor = DepthProcessor::from_paths(depth_files, min_gq, sample_map)?;
 
     let output_zarr = DepthArrays::create_new(
         output_path,
@@ -54,7 +60,7 @@ mod tests {
 
         let depth_files = vec![PathBuf::from(path)];
 
-        run_collect(depth_files, output_path.clone(), 100, None).unwrap();
+        run_collect(depth_files, output_path.clone(), 100, None, None).unwrap();
 
         assert!(output_path.exists());
 
@@ -87,7 +93,7 @@ mod tests {
 
         let depth_files: Vec<PathBuf> = paths.iter().map(|p| PathBuf::from(p)).collect();
 
-        run_collect(depth_files, output_path.clone(), 100, None).unwrap();
+        run_collect(depth_files, output_path.clone(), 100, None, None).unwrap();
 
         assert!(output_path.exists());
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,7 +1,8 @@
 pub mod contig;
 pub mod depth;
 pub mod population;
-pub mod zarr;
+pub mod sample_map;
 pub mod utils;
+pub mod zarr;
 
 

--- a/src/core/sample_map.rs
+++ b/src/core/sample_map.rs
@@ -1,0 +1,212 @@
+use color_eyre::eyre::eyre;
+use color_eyre::Result;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Maps filenames to custom sample names
+#[derive(Debug, Clone)]
+pub struct SampleMap {
+    /// Maps filename (as string) -> sample_name
+    filename_to_sample: HashMap<String, String>,
+}
+
+impl SampleMap {
+    /// Create from a tab-separated file: filename\tsample_name (no header)
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let content = std::fs::read_to_string(path)?;
+
+        let mut filename_to_sample = HashMap::new();
+        let mut sample_names_seen = HashMap::new();
+
+        for (line_num, line) in content.lines().enumerate() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() != 2 {
+                return Err(eyre!(
+                    "Invalid line {} in sample file '{}': expected 2 tab-separated columns, got {}",
+                    line_num + 1,
+                    path.display(),
+                    parts.len()
+                ));
+            }
+
+            let filename = parts[0].to_string();
+            let sample_name = parts[1].to_string();
+
+            // Check for duplicate filenames
+            if filename_to_sample.contains_key(&filename) {
+                return Err(eyre!(
+                    "Duplicate filename '{}' in sample file '{}'",
+                    filename,
+                    path.display()
+                ));
+            }
+
+            // Check for duplicate sample names
+            if let Some(existing_file) = sample_names_seen.get(&sample_name) {
+                return Err(eyre!(
+                    "Duplicate sample name '{}' in sample file '{}' (used by both '{}' and '{}')",
+                    sample_name,
+                    path.display(),
+                    existing_file,
+                    filename
+                ));
+            }
+
+            sample_names_seen.insert(sample_name.clone(), filename.clone());
+            filename_to_sample.insert(filename, sample_name);
+        }
+
+        if filename_to_sample.is_empty() {
+            return Err(eyre!(
+                "Sample file '{}' is empty or contains no valid entries",
+                path.display()
+            ));
+        }
+
+        Ok(Self { filename_to_sample })
+    }
+
+    /// Get sample name for a filename, returning None if not in map
+    pub fn get_sample_name(&self, filename: &str) -> Option<&str> {
+        self.filename_to_sample.get(filename).map(|s| s.as_str())
+    }
+
+    /// Validate that all input files are covered by the sample map
+    pub fn validate_coverage(&self, input_files: &[PathBuf]) -> Result<()> {
+        let missing: Vec<_> = input_files
+            .iter()
+            .filter_map(|path| {
+                let filename = path.file_name()?.to_str()?;
+                if self.filename_to_sample.contains_key(filename) {
+                    None
+                } else {
+                    Some(filename.to_string())
+                }
+            })
+            .collect();
+
+        if !missing.is_empty() {
+            return Err(eyre!(
+                "The following input files are not listed in the sample file: {}",
+                missing.join(", ")
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_parse_sample_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "L.sample1.d4.gz\tL.sample1").unwrap();
+        writeln!(file, "L.sample2.d4.gz\tL.sample2").unwrap();
+
+        let map = SampleMap::from_file(file.path()).unwrap();
+
+        assert_eq!(map.get_sample_name("L.sample1.d4.gz"), Some("L.sample1"));
+        assert_eq!(map.get_sample_name("L.sample2.d4.gz"), Some("L.sample2"));
+        assert_eq!(map.get_sample_name("unknown.d4"), None);
+    }
+
+    #[test]
+    fn test_validate_coverage_success() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "sample1.d4\tsample1").unwrap();
+        writeln!(file, "sample2.d4\tsample2").unwrap();
+
+        let map = SampleMap::from_file(file.path()).unwrap();
+        let files = vec![
+            PathBuf::from("/path/to/sample1.d4"),
+            PathBuf::from("/other/sample2.d4"),
+        ];
+
+        assert!(map.validate_coverage(&files).is_ok());
+    }
+
+    #[test]
+    fn test_validate_coverage_missing_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "sample1.d4\tsample1").unwrap();
+
+        let map = SampleMap::from_file(file.path()).unwrap();
+        let files = vec![
+            PathBuf::from("sample1.d4"),
+            PathBuf::from("sample2.d4"), // Not in map
+        ];
+
+        let result = map.validate_coverage(&files);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("sample2.d4"));
+    }
+
+    #[test]
+    fn test_duplicate_filename_error() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "sample1.d4\tsample1").unwrap();
+        writeln!(file, "sample1.d4\tsample1_dup").unwrap(); // Duplicate filename
+
+        let result = SampleMap::from_file(file.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Duplicate filename"));
+    }
+
+    #[test]
+    fn test_duplicate_sample_name_error() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "sample1.d4\tshared_name").unwrap();
+        writeln!(file, "sample2.d4\tshared_name").unwrap(); // Duplicate sample name
+
+        let result = SampleMap::from_file(file.path());
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Duplicate sample name"));
+    }
+
+    #[test]
+    fn test_empty_file_error() {
+        let file = NamedTempFile::new().unwrap();
+        // File is empty
+
+        let result = SampleMap::from_file(file.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty"));
+    }
+
+    #[test]
+    fn test_invalid_line_format() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "only_one_column").unwrap();
+
+        let result = SampleMap::from_file(file.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("2 tab-separated"));
+    }
+
+    #[test]
+    fn test_skips_empty_lines() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "sample1.d4\tsample1").unwrap();
+        writeln!(file).unwrap(); // Empty line
+        writeln!(file, "   ").unwrap(); // Whitespace only
+        writeln!(file, "sample2.d4\tsample2").unwrap();
+
+        let map = SampleMap::from_file(file.path()).unwrap();
+        assert_eq!(map.get_sample_name("sample1.d4"), Some("sample1"));
+        assert_eq!(map.get_sample_name("sample2.d4"), Some("sample2"));
+    }
+}

--- a/src/loci/mod.rs
+++ b/src/loci/mod.rs
@@ -1,6 +1,7 @@
 use crate::core::depth::array::{build_pop_membership, MultisampleDepthArray};
 use crate::core::depth::DepthProcessor;
 use crate::core::population::PopulationMap;
+use crate::core::sample_map::SampleMap;
 use crate::core::utils::{create_progress_bar, create_spinner};
 use crate::core::zarr::{CallableArrays, DepthArrays, SampleMaskArrays};
 use color_eyre::Result;
@@ -34,8 +35,9 @@ pub fn run_loci(
     chunk_size: u64,
     output_per_sample_mask: bool,
     min_gq: Option<isize>,
+    sample_map: Option<&SampleMap>,
 ) -> Result<()> {
-    let processor = DepthProcessor::from_paths(depth_files, min_gq)?;
+    let processor = DepthProcessor::from_paths(depth_files, min_gq, sample_map)?;
 
     let spinner = create_spinner("Validating population map...");
     //TODO: check that threshold per contig matches depth processor contigs
@@ -292,6 +294,7 @@ mod tests {
             100,
             false,
             None,
+            None,
         )
         .unwrap();
 
@@ -343,6 +346,7 @@ mod tests {
             thresholds,
             100,
             false,
+            None,
             None,
         )
         .unwrap();
@@ -399,6 +403,7 @@ mod tests {
             100,
             true,
             None,
+            None,
         )
         .unwrap();
 
@@ -451,6 +456,7 @@ mod tests {
             thresholds,
             100,
             true,
+            None,
             None,
         )
         .unwrap();


### PR DESCRIPTION
Add --sample-file option to collect and loci commands, allowing users to override auto-detected sample names via a two-column tab-separated file (filename, sample_name).

This solves the issue where filenames with dots (e.g., "L.sample1.d4") are incorrectly parsed as sample name "L" instead of "L.sample1".

Usage:
  clam collect -o out.zarr --sample-file samples.tsv *.d4.gz
  clam loci -o callable.zarr --sample-file samples.tsv *.d4.gz